### PR TITLE
Ensure that parallelism is set properly

### DIFF
--- a/okgo/check/check.go
+++ b/okgo/check/check.go
@@ -67,6 +67,11 @@ func Run(projectParam okgo.ProjectParam, checkersToRun []okgo.CheckerType, pkgPa
 	jobs := make(chan okgo.CheckerParam)
 	results := make(chan checkResult, len(checkers))
 
+	// if there are fewer checkers than max parallelism, update parallelism to number of checkers
+	if len(checkers) < parallelism {
+		parallelism = len(checkers)
+	}
+
 	for w := 0; w < parallelism; w++ {
 		go singleCheckWorker(pkgPaths, projectDir, maxTypeLen, parallelism > 1, jobs, results, stdout)
 	}


### PR DESCRIPTION
If parallelism is greater than number of checks to run, set to
be number of checks to run.