### PR TITLE
Remove release tag configuration

### DIFF
--- a/integration_test/integration_test.go
+++ b/integration_test/integration_test.go
@@ -45,8 +45,7 @@ exclude:
 				Legacy:     true,
 				WantOutput: "Upgraded configuration for check-plugin.yml\n",
 				WantFiles: map[string]string{
-					"godel/config/check-plugin.yml": `release-tag: go1.7
-exclude:
+					"godel/config/check-plugin.yml": `exclude:
   names:
   - m?cks
   paths:

--- a/okgo/config/config.go
+++ b/okgo/config/config.go
@@ -55,8 +55,7 @@ func (c *ProjectConfig) ToParam(factory okgo.CheckerFactory) (okgo.ProjectParam,
 	}
 
 	return okgo.ProjectParam{
-		ReleaseTag: c.ReleaseTag,
-		Checks:     checks,
+		Checks: checks,
 	}, nil
 }
 

--- a/okgo/config/internal/legacy/legacy.go
+++ b/okgo/config/internal/legacy/legacy.go
@@ -77,8 +77,7 @@ func UpgradeConfig(cfgBytes []byte, factory okgo.CheckerFactory) ([]byte, error)
 func upgradeLegacyConfig(legacyCfg ProjectConfig, factory okgo.CheckerFactory) (*v0.ProjectConfig, error) {
 	// upgrade top-level configuration
 	upgradedCfg := v0.ProjectConfig{
-		ReleaseTag: legacyCfg.ReleaseTag,
-		Exclude:    legacyCfg.Exclude,
+		Exclude: legacyCfg.Exclude,
 	}
 
 	// delegate to asset upgraders

--- a/okgo/config/internal/v0/config.go
+++ b/okgo/config/internal/v0/config.go
@@ -26,14 +26,6 @@ import (
 )
 
 type ProjectConfig struct {
-	// ReleaseTag specifies the newest Go release build tag supported by the codebase being checked. If this value
-	// is not specified, it defaults to the Go release that was used to build the check tool. If the code being
-	// checked is known to use a version of Go that is earlier than the version of Go used to build the check tool
-	// and the codebase being checked contains build tags for the newer Go version, this value should be explicitly
-	// set. For example, if the check tool was compiled using Go 1.8 but the codebase being checked uses Go 1.7 and
-	// contains files that use the "// +build go1.8" build tag, then this should be set to "go1.7".
-	ReleaseTag string `yaml:"release-tag,omitempty"`
-
 	// Checks specifies the configuration used by the checks. The key is the name of the check and the value is the
 	// custom configuration for that check.
 	Checks map[okgo.CheckerType]CheckerConfig `yaml:"checks,omitempty"`


### PR DESCRIPTION
Configuration was not being used in any meaningful way, so remove
it from configuration.