### PR TITLE
Do not filter out issues matching exclude path

### DIFF
--- a/changelog/@unreleased/pr-104.v2.yml
+++ b/changelog/@unreleased/pr-104.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Issues reported by checks that have paths that are matched by the "exclude" directive (either in global godel configuration or in check-plugin configuration) are no longer ignored.
+  links:
+  - https://github.com/palantir/okgo/pull/104

--- a/okgo/check/check.go
+++ b/okgo/check/check.go
@@ -186,11 +186,6 @@ func runCheck(checkerType okgo.CheckerType, outputPrefix string, checkerParam ok
 			line := scanner.Text()
 			issue := okgo.NewIssueFromJSON(line)
 
-			if issue.Path != "" && checkerParam.Exclude != nil && checkerParam.Exclude.Match(issue.Path) {
-				// if path matches exclude, skip
-				continue
-			}
-
 			// if issue matches filter, skip
 			filterOut := false
 			for _, filter := range checkerParam.Filters {


### PR DESCRIPTION
Previously, if a check reported an issue in a package that matched
the godel "exclude" directive, it was ignored. However, if a check
reports an issue in an excluded package despite the package not
being provided to the check, there is a good likelihood that the
issue is pertinent and should not be ignored.

Fixes #103

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Issues reported by checks that have paths that are matched by the "exclude" directive (either in global godel configuration or in check-plugin configuration) are no longer ignored. 
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

