### PR TITLE
Revert "Do not filter out issues matching exclude path (#104)"

### DIFF
--- a/changelog/@unreleased/pr-109.v2.yml
+++ b/changelog/@unreleased/pr-109.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: |-
+    Restore previous behavior (behavior of v1.10.0 and earlier) of skipping issues that occur
+    in files that match exclude criteria.
+  links:
+  - https://github.com/palantir/okgo/pull/109

--- a/okgo/check/check.go
+++ b/okgo/check/check.go
@@ -186,6 +186,11 @@ func runCheck(checkerType okgo.CheckerType, outputPrefix string, checkerParam ok
 			line := scanner.Text()
 			issue := okgo.NewIssueFromJSON(line)
 
+			if issue.Path != "" && checkerParam.Exclude != nil && checkerParam.Exclude.Match(issue.Path) {
+				// if path matches exclude, skip
+				continue
+			}
+
 			// if issue matches filter, skip
 			filterOut := false
 			for _, filter := range checkerParam.Filters {


### PR DESCRIPTION
Restore previous behavior of skipping issues that match exclude
criteria. The reasoning for changing this behavior was incorrect:
the thought was that the exclude list controlling the input packages
would be sufficient. However, exclude criteria can also match at the
level of individual files, and there is no good way to support this
behavior. Because the original PR being reverted by this commit was
made to enable specific edge-case behavior (showing failures for
"compiles" check even if errors are reported in paths that are
specified as ignore paths), it is not worth breaking this general
case.

This reverts commit e7caa5d881615fb7b828a404a7178ae34b36b729.

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Restore previous behavior (behavior of v1.10.0 and earlier) of skipping issues that occur
in files that match exclude criteria.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

