### PR TITLE
Write Go files with an internal helper instead of gofiles.Write

### DIFF
--- a/okgotester/okgotester.go
+++ b/okgotester/okgotester.go
@@ -81,7 +81,7 @@ func RunAssetCheckTest(t *testing.T,
 			require.NoError(t, err)
 		}
 
-		_, err = gofiles.Write(projectDir, tc.Specs)
+		err = writeGoFiles(projectDir, tc.Specs)
 		require.NoError(t, err)
 
 		outputBuf := &bytes.Buffer{}
@@ -111,4 +111,23 @@ func RunAssetCheckTest(t *testing.T,
 			assert.Equal(t, tc.WantOutput, outputBuf.String(), "Case %d: %s", i, tc.Name)
 		}()
 	}
+}
+
+// writeGoFiles to the provided directory as the root directory.
+func writeGoFiles(dir string, files []gofiles.GoFileSpec) error {
+	dir, err := filepath.Abs(dir)
+	if err != nil {
+		return err
+	}
+
+	for _, currFile := range files {
+		filePath := filepath.Join(dir, currFile.RelPath)
+		if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+			return err
+		}
+		if err := os.WriteFile(filePath, []byte(currFile.Src), 0644); err != nil {
+			return err
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
## Before this PR
A break (no more template rendering) and a behavior change (using packages.Load to get module paths instead of $GOPATH) in nmiyake/pkg/gofiles caused tests to fail on https://github.com/palantir/godel-okgo-asset-importalias/pull/132 since we're no longer writing `go.mod` files.

All usages of gofiles.Write did not inspect the returned import paths, so instead of using that function, we can use an internal function to write out the raw Go files avoiding any package loading and only returning errors for writing the files.

This is almost identical to what was done for distgo here: https://github.com/palantir/distgo/pull/237
## After this PR
==COMMIT_MSG==
Write Go files with an internal helper instead of gofiles.Write
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

