### PR TITLE
fix: Wait to instantiate checker until single run cmd is invoked

### DIFF
--- a/changelog/@unreleased/pr-325.v2.yml
+++ b/changelog/@unreleased/pr-325.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Wait to instantiate checker until single run cmd is invoked
+  links:
+  - https://github.com/palantir/okgo/pull/325

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -38,13 +38,13 @@ func addRunSubcommands() {
 }
 
 func createSingleRunCmd(checkerType okgo.CheckerType, factory okgo.CheckerFactory) *cobra.Command {
-	checker, err := factory.NewChecker(checkerType, nil)
-	if err != nil {
-		panic(errors.Wrapf(err, "failed to create command for checker type %s", checkerType))
-	}
 	return &cobra.Command{
 		Use: string(checkerType),
 		Run: func(cmd *cobra.Command, args []string) {
+			checker, err := factory.NewChecker(checkerType, nil)
+			if err != nil {
+				panic(errors.Wrapf(err, "failed to create command for checker type %s", checkerType))
+			}
 			checker.RunCheckCmd(args, cmd.OutOrStdout())
 		},
 	}


### PR DESCRIPTION
- Wait to instantiate checker until single run cmd is invoked
- Part of https://github.com/palantir/okgo/issues/326
- The subcommand of running a single-check is rarely uses, however currently we instantiate the entire plugin before invocation. This move instantiation to occur only in the rare case that a single check is called. Currently it is also called during the base initialization of assets, which is unneeded


## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

