### PR TITLE
fix: Attach the checkerType and checkerPriority to the assetChecker itself because they are immutable

### DIFF
--- a/checker/checker_asset.go
+++ b/checker/checker_asset.go
@@ -15,7 +15,6 @@
 package checker
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"os/exec"
@@ -27,34 +26,18 @@ import (
 )
 
 type assetChecker struct {
-	assetPath string
-	cfgYML    string
+	assetPath       string
+	cfgYML          string
+	checkerType     okgo.CheckerType
+	checkerPriority okgo.CheckerPriority
 }
 
 func (c *assetChecker) Type() (okgo.CheckerType, error) {
-	nameCmd := exec.Command(c.assetPath, typeCmdName)
-	outputBytes, err := runCommand(nameCmd)
-	if err != nil {
-		return "", err
-	}
-	var checkerType okgo.CheckerType
-	if err := json.Unmarshal(outputBytes, &checkerType); err != nil {
-		return "", errors.Wrapf(err, "failed to unmarshal JSON")
-	}
-	return checkerType, nil
+	return c.checkerType, nil
 }
 
 func (c *assetChecker) Priority() (okgo.CheckerPriority, error) {
-	nameCmd := exec.Command(c.assetPath, priorityCmdName)
-	outputBytes, err := runCommand(nameCmd)
-	if err != nil {
-		return 0, err
-	}
-	var checkerPriority okgo.CheckerPriority
-	if err := json.Unmarshal(outputBytes, &checkerPriority); err != nil {
-		return 0, errors.Wrapf(err, "failed to unmarshal JSON")
-	}
-	return checkerPriority, nil
+	return c.checkerPriority, nil
 }
 
 func (c *assetChecker) VerifyConfig() error {

--- a/checker/checkers.go
+++ b/checker/checkers.go
@@ -18,12 +18,13 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"github.com/palantir/okgo/okgo"
-	"github.com/pkg/errors"
 	"io"
 	"os"
 	"os/exec"
 	"sort"
+
+	"github.com/palantir/okgo/okgo"
+	"github.com/pkg/errors"
 )
 
 type CreatorFunction func(cfgYML []byte) (okgo.Checker, error)

--- a/checker/checkers.go
+++ b/checker/checkers.go
@@ -18,13 +18,12 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"github.com/palantir/okgo/okgo"
+	"github.com/pkg/errors"
 	"io"
 	"os"
 	"os/exec"
 	"sort"
-
-	"github.com/palantir/okgo/okgo"
-	"github.com/pkg/errors"
 )
 
 type CreatorFunction func(cfgYML []byte) (okgo.Checker, error)
@@ -65,25 +64,23 @@ func AssetCheckerCreators(assetPaths ...string) ([]Creator, []okgo.ConfigUpgrade
 	var checkerCreators []Creator
 	var configUpgraders []okgo.ConfigUpgrader
 	checkerTypeToAssets := make(map[okgo.CheckerType][]string)
+	typeAndPriorities, err := determineTypeAndPriorityForPaths(assetPaths)
+	if err != nil {
+		return nil, nil, err
+	}
 	for _, currAssetPath := range assetPaths {
 		currAssetPath := currAssetPath
-		currChecker := assetChecker{
-			assetPath: currAssetPath,
-		}
-		checkerType, err := currChecker.Type()
-		if err != nil {
-			return nil, nil, errors.Wrapf(err, "failed to determine Checker type name for asset %s", currAssetPath)
-		}
-		checkerPriority, err := currChecker.Priority()
-		if err != nil {
-			return nil, nil, errors.Wrapf(err, "failed to determine Checker priority for asset %s", currAssetPath)
-		}
+		typeAndPriority := typeAndPriorities[currAssetPath]
+		checkerType := typeAndPriority.checkerType
+		checkerPriority := typeAndPriority.checkerPriority
 		checkerTypeToAssets[checkerType] = append(checkerTypeToAssets[checkerType], currAssetPath)
 		checkerCreators = append(checkerCreators, NewCreator(checkerType, checkerPriority,
 			func(cfgYML []byte) (okgo.Checker, error) {
 				newChecker := assetChecker{
-					assetPath: currAssetPath,
-					cfgYML:    string(cfgYML),
+					assetPath:       currAssetPath,
+					cfgYML:          string(cfgYML),
+					checkerType:     checkerType,
+					checkerPriority: checkerPriority,
 				}
 				if err := newChecker.VerifyConfig(); err != nil {
 					return nil, err
@@ -108,6 +105,49 @@ func AssetCheckerCreators(assetPaths ...string) ([]Creator, []okgo.ConfigUpgrade
 		return nil, nil, errors.Errorf("Checker type %s provided by multiple assets: %v", k, checkerTypeToAssets[k])
 	}
 	return checkerCreators, configUpgraders, nil
+}
+
+type typeAndPriority struct {
+	checkerType     okgo.CheckerType
+	checkerPriority okgo.CheckerPriority
+}
+
+func determineTypeAndPriorityForPaths(assetPaths []string) (map[string]typeAndPriority, error) {
+	typeAndPriorities := map[string]typeAndPriority{}
+	for _, assetPath := range assetPaths {
+		typeAndPriorityForAsset, err := determineTypeAndPriority(assetPath)
+		if err != nil {
+			return nil, err
+		}
+		typeAndPriorities[assetPath] = typeAndPriorityForAsset
+
+	}
+	return typeAndPriorities, nil
+}
+
+func determineTypeAndPriority(assetPath string) (typeAndPriority, error) {
+	nameCmd := exec.Command(assetPath, typeCmdName)
+	outputBytes, err := runCommand(nameCmd)
+	if err != nil {
+		return typeAndPriority{}, err
+	}
+	var checkerType okgo.CheckerType
+	if err := json.Unmarshal(outputBytes, &checkerType); err != nil {
+		return typeAndPriority{}, errors.Wrapf(err, "failed to unmarshal JSON")
+	}
+	priorityCmd := exec.Command(assetPath, priorityCmdName)
+	outputBytes, err = runCommand(priorityCmd)
+	if err != nil {
+		return typeAndPriority{}, err
+	}
+	var checkerPriority okgo.CheckerPriority
+	if err := json.Unmarshal(outputBytes, &checkerPriority); err != nil {
+		return typeAndPriority{}, errors.Wrapf(err, "failed to unmarshal JSON")
+	}
+	return typeAndPriority{
+		checkerType:     checkerType,
+		checkerPriority: checkerPriority,
+	}, nil
 }
 
 // RunCommandAndStreamOutput runs the provided exec.Cmd. The output that is generated to Stdout and Stderr for the


### PR DESCRIPTION
- Part of  #326
- Attach the checkerType and checkerPriority to the assetChecker itself because they are immutable
- Remove the awkwardness of https://github.com/palantir/okgo/pull/324/files#diff-c2a8ec68ae9b6f53af99349dd688d855f8f9f5a33790ed5a1161a09c7e4442f6L70 in which we instantiate an assetChecker struct to get the priority/type, just to recreate the struct
- These get called during sort, so they are called frequently


## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

