### PR TITLE
improvement: Add helper functions and tests to `check.Run`

### DIFF
--- a/changelog/@unreleased/pr-340.v2.yml
+++ b/changelog/@unreleased/pr-340.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add helper functions and tests to `check.Run`
+  links:
+  - https://github.com/palantir/okgo/pull/340

--- a/okgo/check/check_test.go
+++ b/okgo/check/check_test.go
@@ -26,6 +26,7 @@ import (
 )
 
 type inMemoryChecker struct {
+	okgo.Checker
 	checkerType okgo.CheckerType
 	issue       *okgo.Issue
 }
@@ -44,10 +45,6 @@ func (i *inMemoryChecker) Check(pkgPaths []string, projectDir string, stdout io.
 	}
 	bytes, _ := json.Marshal(i.issue)
 	_, _ = stdout.Write(bytes)
-}
-
-func (i *inMemoryChecker) RunCheckCmd(args []string, stdout io.Writer) {
-	panic("implement RunCheckCmd")
 }
 
 func TestRun_NoErrors(t *testing.T) {
@@ -113,6 +110,5 @@ func TestRun_ErrorsButFilteredOut(t *testing.T) {
 		"test2",
 	}
 	err := Run(projectParam, checkersToRun, []string{"p1"}, "dir", nil, 2, os.Stdout)
-
 	assert.NoError(t, err)
 }

--- a/okgo/check/check_test.go
+++ b/okgo/check/check_test.go
@@ -1,0 +1,118 @@
+// Copyright 2024 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package check
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/palantir/okgo/okgo"
+	"github.com/palantir/pkg/matcher"
+	"github.com/stretchr/testify/assert"
+)
+
+type inMemoryChecker struct {
+	checkerType okgo.CheckerType
+	issue       *okgo.Issue
+}
+
+func (i *inMemoryChecker) Type() (okgo.CheckerType, error) {
+	return i.checkerType, nil
+}
+
+func (i *inMemoryChecker) Priority() (okgo.CheckerPriority, error) {
+	return 0, nil
+}
+
+func (i *inMemoryChecker) Check(pkgPaths []string, projectDir string, stdout io.Writer) {
+	if i.issue == nil {
+		return
+	}
+	bytes, _ := json.Marshal(i.issue)
+	_, _ = stdout.Write(bytes)
+}
+
+func (i *inMemoryChecker) RunCheckCmd(args []string, stdout io.Writer) {
+	panic("implement RunCheckCmd")
+}
+
+func TestRun_NoErrors(t *testing.T) {
+	projectParam := okgo.ProjectParam{
+		Checks: map[okgo.CheckerType]okgo.CheckerParam{
+			"test1": {
+				Checker: &inMemoryChecker{checkerType: "test1"},
+			},
+			"test2": {
+				Checker: &inMemoryChecker{checkerType: "test2"},
+			},
+		},
+	}
+	checkersToRun := []okgo.CheckerType{
+		"test1",
+		"test2",
+	}
+	err := Run(projectParam, checkersToRun, nil, "dir", nil, 2, os.Stdout)
+	assert.NoError(t, err)
+}
+
+func TestRun_Errors(t *testing.T) {
+	projectParam := okgo.ProjectParam{
+		Checks: map[okgo.CheckerType]okgo.CheckerParam{
+			"test1": {
+				Checker: &inMemoryChecker{checkerType: "test1", issue: &okgo.Issue{
+					Content: "output",
+				}},
+			},
+			"test2": {
+				Checker: &inMemoryChecker{checkerType: "test2"},
+			},
+		},
+	}
+	checkersToRun := []okgo.CheckerType{
+		"test1",
+		"test2",
+	}
+	err := Run(projectParam, checkersToRun, nil, "dir", nil, 2, os.Stdout)
+	assert.Error(t, err)
+}
+
+func TestRun_ErrorsButFilteredOut(t *testing.T) {
+	projectParam := okgo.ProjectParam{
+		Checks: map[okgo.CheckerType]okgo.CheckerParam{
+			"test1": {
+				Skip: true,
+				Checker: &inMemoryChecker{checkerType: "test1", issue: &okgo.Issue{
+					Content: "output",
+				}},
+			},
+			"test2": {
+				Exclude: matcher.Name("p1"),
+				Checker: &inMemoryChecker{checkerType: "test2", issue: &okgo.Issue{
+					Path:    "p1",
+					Content: "output",
+				}},
+			},
+		},
+	}
+	checkersToRun := []okgo.CheckerType{
+		"test1",
+		"test2",
+	}
+	err := Run(projectParam, checkersToRun, []string{"p1"}, "dir", nil, 2, os.Stdout)
+
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
- Add helper functions and tests to check.Run. This code is currently untested, we can use in-memory checkers to ensure that we are skipping and running the correct checks
- Adding tests around the code path in which https://github.com/palantir/okgo/issues/339 is being hit

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

