### PR TITLE
fix: Fix a race condition in `check.Run` in which a checker failing to return its check type causes a deadlock

### DIFF
--- a/changelog/@unreleased/pr-342.v2.yml
+++ b/changelog/@unreleased/pr-342.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fix a race condition in `check.Run` in which a checker failing to return
+    its check type causes a deadlock
+  links:
+  - https://github.com/palantir/okgo/pull/342

--- a/okgo/check/check_test.go
+++ b/okgo/check/check_test.go
@@ -15,6 +15,7 @@
 package check
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"io"
@@ -34,7 +35,7 @@ type inMemoryChecker struct {
 
 func (i *inMemoryChecker) Type() (okgo.CheckerType, error) {
 	if i.checkerType == "error_on_type_check" {
-		return "", errors.New("hi")
+		return "", errors.New("test error on Type()")
 	}
 	return i.checkerType, nil
 }
@@ -128,6 +129,8 @@ func TestRun_ErrorsOnTypeCheck(t *testing.T) {
 	checkersToRun := []okgo.CheckerType{
 		"error_on_type_check",
 	}
-	err := Run(projectParam, checkersToRun, nil, "dir", nil, 2, os.Stdout)
+	buffer := &bytes.Buffer{}
+	err := Run(projectParam, checkersToRun, nil, "dir", nil, 2, buffer)
 	assert.Error(t, err)
+	assert.Contains(t, buffer.String(), "test error on Type()")
 }

--- a/okgo/check/check_test.go
+++ b/okgo/check/check_test.go
@@ -16,6 +16,7 @@ package check
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"os"
 	"testing"
@@ -32,6 +33,9 @@ type inMemoryChecker struct {
 }
 
 func (i *inMemoryChecker) Type() (okgo.CheckerType, error) {
+	if i.checkerType == "error_on_type_check" {
+		return "", errors.New("hi")
+	}
 	return i.checkerType, nil
 }
 
@@ -111,4 +115,19 @@ func TestRun_ErrorsButFilteredOut(t *testing.T) {
 	}
 	err := Run(projectParam, checkersToRun, []string{"p1"}, "dir", nil, 2, os.Stdout)
 	assert.NoError(t, err)
+}
+
+func TestRun_ErrorsOnTypeCheck(t *testing.T) {
+	projectParam := okgo.ProjectParam{
+		Checks: map[okgo.CheckerType]okgo.CheckerParam{
+			"error_on_type_check": {
+				Checker: &inMemoryChecker{checkerType: "error_on_type_check"},
+			},
+		},
+	}
+	checkersToRun := []okgo.CheckerType{
+		"error_on_type_check",
+	}
+	err := Run(projectParam, checkersToRun, nil, "dir", nil, 2, os.Stdout)
+	assert.Error(t, err)
 }


### PR DESCRIPTION
- Fix a race condition in check.Run in which a checker failing to return its check type causes a deadlock
- Right now if:
```
		checkerType, err := checkerParam.Checker.Type()
		if err != nil {
			_, _ = fmt.Fprintf(stdout, "failed to determine type for Checker: %v", err)
			continue
		}
```
is hit, then we do not add a checkResult to the `results` channel. This causes a deadlock because we never pull off the numbers of checkResults we expect
- Part of the fix to https://github.com/palantir/okgo/issues/339
- Add a test to verify this behavrior.

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

