### PR TITLE
improvement: Attempt to invoke the MultiCPU cli command to determine if the plugin use multiple CPUs. Defaults to false

### DIFF
--- a/changelog/@unreleased/pr-344.v2.yml
+++ b/changelog/@unreleased/pr-344.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Attempt to invoke the MultiCPU cli command to determine if the plugin
+    use multiple CPUs. Defaults to false
+  links:
+  - https://github.com/palantir/okgo/pull/344


### PR DESCRIPTION
- Attempt to invoke the MultiCPU cli command to determine if the plugin use multiple CPUs. Defaults to false 
- Will be used to partially solve https://github.com/palantir/okgo/issues/339
- Currently this field is not read

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

