### PR TITLE
improvement: Only run jobs in parallel that do not advertise needing multiple CPUs

### DIFF
--- a/changelog/@unreleased/pr-345.v2.yml
+++ b/changelog/@unreleased/pr-345.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Only run jobs in parallel that do not advertise needing multiple CPUs
+  links:
+  - https://github.com/palantir/okgo/pull/345

--- a/changelog/@unreleased/pr-345.v2.yml
+++ b/changelog/@unreleased/pr-345.v2.yml
@@ -1,5 +1,5 @@
 type: improvement
 improvement:
-  description: Only run jobs in parallel that do not advertise needing multiple CPUs
+  description: Update check running logic so that all checks that report using multiple CPUs are run serially and then the rest of the checks are run in parallel.
   links:
   - https://github.com/palantir/okgo/pull/345

--- a/okgo/check/check_test.go
+++ b/okgo/check/check_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/palantir/okgo/okgo"
 	"github.com/palantir/pkg/matcher"
@@ -30,7 +31,9 @@ import (
 type inMemoryChecker struct {
 	okgo.Checker
 	checkerType okgo.CheckerType
+	multiCPU    okgo.CheckerMultiCPU
 	issue       *okgo.Issue
+	timeToWait  *time.Duration
 }
 
 func (i *inMemoryChecker) Type() (okgo.CheckerType, error) {
@@ -44,7 +47,14 @@ func (i *inMemoryChecker) Priority() (okgo.CheckerPriority, error) {
 	return 0, nil
 }
 
+func (i *inMemoryChecker) MultiCPU() (okgo.CheckerMultiCPU, error) {
+	return i.multiCPU, nil
+}
+
 func (i *inMemoryChecker) Check(pkgPaths []string, projectDir string, stdout io.Writer) {
+	if i.timeToWait != nil {
+		time.Sleep(*i.timeToWait)
+	}
 	if i.issue == nil {
 		return
 	}
@@ -133,4 +143,104 @@ func TestRun_ErrorsOnTypeCheck(t *testing.T) {
 	err := Run(projectParam, checkersToRun, nil, "dir", nil, 2, buffer)
 	assert.Error(t, err)
 	assert.Contains(t, buffer.String(), "test error on Type()")
+}
+
+func TestRun_NoErrorsWithWaits(t *testing.T) {
+	timeToWait := time.Millisecond * 50
+	projectParam := okgo.ProjectParam{
+		Checks: map[okgo.CheckerType]okgo.CheckerParam{
+			"test1": {
+				Checker: &inMemoryChecker{
+					checkerType: "test1",
+					timeToWait:  toDuration(timeToWait),
+				},
+			},
+			"test2": {
+				Checker: &inMemoryChecker{
+					checkerType: "test2",
+					timeToWait:  toDuration(timeToWait),
+				},
+			},
+			"test3": {
+				Checker: &inMemoryChecker{
+					checkerType: "test3",
+					timeToWait:  toDuration(timeToWait),
+				},
+			},
+			"test4": {
+				Checker: &inMemoryChecker{
+					checkerType: "test4",
+					timeToWait:  toDuration(timeToWait),
+				},
+			},
+		},
+	}
+	checkersToRun := []okgo.CheckerType{
+		"test1",
+		"test2",
+		"test3",
+		"test4",
+	}
+	// Ensure with max parallelism we can run all of them
+	start := time.Now()
+	err := Run(projectParam, checkersToRun, nil, "dir", nil, 4, os.Stdout)
+	assert.NoError(t, err)
+	assert.Greater(t, time.Now().Sub(start), timeToWait)
+	assert.Less(t, time.Now().Sub(start), timeToWait*2)
+
+	// And scaled down we take longer
+	start = time.Now()
+	err = Run(projectParam, checkersToRun, nil, "dir", nil, 2, os.Stdout)
+	assert.NoError(t, err)
+	assert.Greater(t, time.Now().Sub(start), timeToWait*2)
+	assert.Less(t, time.Now().Sub(start), timeToWait*3)
+}
+
+func TestRun_NoErrorsWithWaitsAndSplit(t *testing.T) {
+	timeToWait := time.Millisecond * 50
+	projectParam := okgo.ProjectParam{
+		Checks: map[okgo.CheckerType]okgo.CheckerParam{
+			"test1": {
+				Checker: &inMemoryChecker{
+					checkerType: "test1",
+					timeToWait:  toDuration(timeToWait),
+					multiCPU:    true,
+				},
+			},
+			"test2": {
+				Checker: &inMemoryChecker{
+					checkerType: "test2",
+					timeToWait:  toDuration(timeToWait),
+				},
+			},
+			"test3": {
+				Checker: &inMemoryChecker{
+					checkerType: "test3",
+					timeToWait:  toDuration(timeToWait),
+					multiCPU:    true,
+				},
+			},
+			"test4": {
+				Checker: &inMemoryChecker{
+					checkerType: "test4",
+					timeToWait:  toDuration(timeToWait),
+				},
+			},
+		},
+	}
+	checkersToRun := []okgo.CheckerType{
+		"test1",
+		"test2",
+		"test3",
+		"test4",
+	}
+	start := time.Now()
+	err := Run(projectParam, checkersToRun, nil, "dir", nil, 2, os.Stdout)
+	assert.NoError(t, err)
+	assert.Greater(t, time.Now().Sub(start), timeToWait*3)
+	assert.Less(t, time.Now().Sub(start), timeToWait*4)
+}
+
+func toDuration(timeToWait time.Duration) *time.Duration {
+	return &timeToWait
 }


### PR DESCRIPTION
- Last PR for https://github.com/palantir/okgo/issues/339 on the okgo side of things
- We will split out jobs that need and do not need multiple CPUs, and then we will runs the jobs the need multiple CPUs first in a non parallel manner
- Once they all finish, we can run the rest in parallel up to the parallelism configuration that has been set


## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

